### PR TITLE
Undefined name: name -> os.name, system -> os.system

### DIFF
--- a/Modes/Gmode.py
+++ b/Modes/Gmode.py
@@ -29,7 +29,7 @@ SOFTWARE.
 import requests # in DEV
 import proxybroker # in DEV
 from googlesearch import search
-import sys
+from os import system
 import sys
 from termcolor import colored, cprint
 import warnings

--- a/Modes/Gmode.py
+++ b/Modes/Gmode.py
@@ -29,7 +29,7 @@ SOFTWARE.
 import requests # in DEV
 import proxybroker # in DEV
 from googlesearch import search
-from os import system
+import os
 import sys
 from termcolor import colored, cprint
 import warnings
@@ -42,14 +42,9 @@ with warnings.catch_warnings():
     fxn()
 
 def clear(): 
-  
-    if name == 'nt': 
-        _ = system('cls') 
-    else: 
-        _ = system('clear') 
-        
-        
-    
+    return os.system('cls' if os.name == 'nt' else 'clear')
+
+
 print ("")
 
 A = """

--- a/Modes/Scada.py
+++ b/Modes/Scada.py
@@ -33,15 +33,10 @@ import sys
 import os
 import time
 from googlesearch import search
-import sys
 from termcolor import colored, cprint
 
 def clear(): 
-  
-    if name == 'nt': 
-        _ = system('cls') 
-    else: 
-        _ = system('clear') 
+    return os.system('cls' if os.name == 'nt' else 'clear')
        
 
 NPP = """ 


### PR DESCRIPTION
flake8 testing of https://github.com/adnane-X-tebbaa/Katana on Python 3.8.1

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./Modes/Scada.py:41:8: F821 undefined name 'name'
    if name == 'nt': 
       ^
./Modes/Scada.py:42:13: F821 undefined name 'system'
        _ = system('cls')
            ^
./Modes/Scada.py:44:13: F821 undefined name 'system'
        _ = system('clear') 
            ^
./Modes/Gmode.py:46:8: F821 undefined name 'name'
    if name == 'nt': 
       ^
./Modes/Gmode.py:47:13: F821 undefined name 'system'
        _ = system('cls') 
            ^
./Modes/Gmode.py:49:13: F821 undefined name 'system'
        _ = system('clear') 
            ^
6     F821 undefined name 'name'
6
```